### PR TITLE
g3: dm-req-crypt: properly close the current device

### DIFF
--- a/drivers/md/dm-req-crypt.c
+++ b/drivers/md/dm-req-crypt.c
@@ -769,6 +769,9 @@ static void req_crypt_dtr(struct dm_target *ti)
 {
 	DMDEBUG("dm-req-crypt Destructor.\n");
 
+	if (dev)
+		dm_put_device(ti, dev);
+
 	if (req_crypt_queue) {
 		destroy_workqueue(req_crypt_queue);
 		req_crypt_queue = NULL;


### PR DESCRIPTION
* When receiving the DM_DEV_REMOVE ioctl command qc didn't properly
  release the current open device which forced further actions on the
  device to fail.

* As a result Android's encryption routine hung up during the test
  remount at 100%.

WARNING: at ../../../../../../kernel/lge/g3/fs/sysfs/dir.c:508 sysfs_add_one+0x94/0xb4()
sysfs: cannot create duplicate filename '/devices/msm_sdcc.1/mmc_host/mmc0/mmc0:0001/block/mmcblk0/mmcblk0p43/holders/dm-0'
[...]
device-mapper: req-crypt:  req_crypt_ctr Device Lookup failed
device-mapper: table: 254:0: req-crypt: Unknown error
device-mapper: ioctl: error adding target to table

Change-Id: I4df99e4ec4c7cd3b0d95677e8f2d3d71f57b0b89